### PR TITLE
Add bindings to all tests

### DIFF
--- a/archive/strx/aie_reconfig_overhead/profile_aie_reconfig.json
+++ b/archive/strx/aie_reconfig_overhead/profile_aie_reconfig.json
@@ -1,5 +1,10 @@
 {
   "version": "1.0",
+  "bindings": [
+    { "name": "bo_ifm", "size": 134217728 },
+    { "name": "bo_ofm", "size": 134217728 },
+    { "name": "bo_inter", "size": 1048576 }
+  ],
   "execution" : {
     "iterations": 1000,
     "verbose": false

--- a/archive/strx/cmd_chain_latency/profile_cmd_chain_latency.json
+++ b/archive/strx/cmd_chain_latency/profile_cmd_chain_latency.json
@@ -1,6 +1,12 @@
 {
   "version": "1.0",
-
+  "bindings": [
+    { "name": "arg0", "size": 20 },
+    { "name": "arg1", "size": 20 },
+    { "name": "arg2", "size": 20 },
+    { "name": "arg3", "size": 20 },
+    { "name": "arg4", "size": 20 }
+  ],
   "execution" : {
     "iterations": 10,
     "verbose": false

--- a/archive/strx/cmd_chain_throughput/profile_cmd_chain_throughput.json
+++ b/archive/strx/cmd_chain_throughput/profile_cmd_chain_throughput.json
@@ -1,6 +1,12 @@
 {
   "version": "1.0",
-
+  "bindings": [
+    { "name": "arg0", "size": 20 },
+    { "name": "arg1", "size": 20 },
+    { "name": "arg2", "size": 20 },
+    { "name": "arg3", "size": 20 },
+    { "name": "arg4", "size": 20 }
+  ],
   "execution" : {
     "iterations": 10,
     "verbose": false

--- a/archive/strx/latency/profile_latency.json
+++ b/archive/strx/latency/profile_latency.json
@@ -1,6 +1,12 @@
 {
   "version": "1.0",
-
+  "bindings": [
+    { "name": "arg0", "size": 20 },
+    { "name": "arg1", "size": 20 },
+    { "name": "arg2", "size": 20 },
+    { "name": "arg3", "size": 20 },
+    { "name": "arg4", "size": 20 }
+  ],
   "execution" : {
     "iterations": 10000,
     "verbose": false

--- a/archive/strx/tct_all_column/profile_tct_all_column.json
+++ b/archive/strx/tct_all_column/profile_tct_all_column.json
@@ -1,6 +1,9 @@
 {
   "version": "1.0",
-
+  "bindings": [
+    { "name": "ifm", "size": 4 },
+    { "name": "ofm", "size": 4 }
+  ],
   "execution" : {
     "iterations": 1000,
     "verbose": false

--- a/archive/strx/tct_one_column/profile_tct_one_column.json
+++ b/archive/strx/tct_one_column/profile_tct_one_column.json
@@ -1,6 +1,9 @@
 {
   "version": "1.0",
-
+  "bindings": [
+    { "name": "ifm", "size": 4 },
+    { "name": "ofm", "size": 16 }
+  ],
   "execution" : {
     "iterations": 500,
     "verbose": false

--- a/archive/strx/throughput/profile_throughput.json
+++ b/archive/strx/throughput/profile_throughput.json
@@ -1,6 +1,12 @@
 {
   "version": "1.0",
-
+  "bindings": [
+    { "name": "arg0", "size": 20 },
+    { "name": "arg1", "size": 20 },
+    { "name": "arg2", "size": 20 },
+    { "name": "arg3", "size": 20 },
+    { "name": "arg4", "size": 20 }
+  ],
   "execution" : {
     "iterations": 2502,
     "verbose": false


### PR DESCRIPTION
This PR adds the binding statements to profile.json
This required since runner no longer creates empty buffers for external buffers (input, output ) which are not specifically bound in profile.json