### PR TITLE
Add vadd ELF for VEK385/T20 shim test support

### DIFF
--- a/archive/ve2/vadd/vadd.elf
+++ b/archive/ve2/vadd/vadd.elf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a0869a80f71501d3c861cbd4bec35b8b358f5590e0c97ef1681d327cde3c6e3a
+size 26056


### PR DESCRIPTION
Add archive/ve2/vadd/ directory containing the vadd.elf binary needed by T20 (VEK385 sentry mode) shim tests.

The T20 platform reuses the npu3 firmware protocol but runs on VE2-class (AIE2PS) silicon. Its shim test suite (45 applicable tests out of 72) requires two ELFs:

  - vadd.elf ("good" tag) -- used by 17 tests including hw_context lifecycle, IO tests, export/import BO, cmd fencing, max context, and heap stress.
  - nop.elf ("nop" tag) -- used by 10 latency/throughput tests. Already present at archive/ve2/latency/nop.elf.

The Yocto pvt recipe in Vitis-AI-Telluride will map these into the runtime path local_shim_test_data/npu3/{vadd,nop}/ expected by dev_info.cpp for npu3_aie2ps_device_id (0xfe02).