### PR TITLE
SWSPLAT-30781 Enhance script to disallow out of tree runs

### DIFF
--- a/archive/README.md
+++ b/archive/README.md
@@ -23,19 +23,22 @@ Use the provided Python script for automated archive creation:
 
 ### Basic Usage
 
-```bash
-# Create archives for all platforms
-python build_archives.py
+One or more platform folder names are **required**. Allowed values: `phx`, `strx`, `npu3`, `ve2`.
 
-# Create archive for specific platform
+```bash
+# Create archive for a single platform
 python build_archives.py strx
 
 # Create archives for multiple platforms
 python build_archives.py phx ve2 strx
 ```
 
+Running without folder arguments fails with a usage error. Unknown or path-traversal folder names (e.g. `../../other`) are refused; only the four platform directories under `archive/` are accepted.
+
 ### Script Features
 
+- **Required platform argument**: At least one of `phx`, `strx`, `npu3`, or `ve2` must be specified
+- **Path safety**: Resolves folders only under this `archive/` directory; rejects other paths
 - **Recursive file collection**: Automatically includes files from subdirectories
 - **Flattened structure**: Creates archives with all files at root level
 - **Smart updates**: Only updates files newer than existing archive
@@ -97,6 +100,7 @@ python build_archives.py --help
 
 ## Notes
 
+- Run `build_archives.py` from any working directory; it always targets platform subdirs under `archive/`
 - Archives are stored in their respective platform directories (e.g., `strx/xrt_smi_strx.a`)
 - All files are flattened to root level in archives (no directory structure preserved)
 - The Python script automatically excludes existing `.a` files to prevent circular inclusion

--- a/archive/build_archives.py
+++ b/archive/build_archives.py
@@ -86,34 +86,37 @@ def create_archive(folder_path):
 def print_help():
     print("""Archive Builder - Create .a archives from folders
 
-USAGE: python build_archives.py [folders...]
-ARGUMENTS: folders - List of folder names (default: all folders in current directory)
+USAGE: python build_archives.py <folder> [folder...]
+ARGUMENTS: folder - One or more platform folder names (phx, strx, npu3, ve2)
 
 EXAMPLES:
-    python build_archives.py          # Create archives for all folders
-    python build_archives.py phx      # Create archive for specific folder
-    python build_archives.py phx ve2  # Create archives for multiple folders
+    python build_archives.py phx
+    python build_archives.py phx ve2 strx
 
-OUTPUT: Archives created as xrt_smi_<foldername>.a""")
+OUTPUT: Archives created as xrt_smi_<foldername>.a inside each platform folder""")
 
 def main():
     check_ar_utility()
     parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument('-h', '--help', action='store_true')
-    parser.add_argument('folders', nargs='*', help='Folder names to create archives for')
+    parser.add_argument('folders', nargs='+', help='Platform folder names (phx, strx, npu3, ve2)')
     args = parser.parse_args()
     
     if args.help:
         print_help()
         return 0
     
-    current_dir = Path(".")
-    folder_names = args.folders or [d.name for d in current_dir.iterdir() if d.is_dir()]
-    if not args.folders:
-        print(f"No folders specified, processing all: {', '.join(folder_names)}")
-    
-    folders = [current_dir / name for name in folder_names if (current_dir / name).exists()]
-    [print(f"Warning: Folder {name} not found, skipping") for name in folder_names if not (current_dir / name).exists()]
+    ARCHIVE_ROOT = Path(__file__).resolve().parent
+    ALLOWED = {"phx", "strx", "npu3", "ve2"}
+    folder_names = args.folders
+
+    folders = []
+    for name in folder_names:
+        cand = (ARCHIVE_ROOT / name).resolve()
+        if name not in ALLOWED or not cand.is_relative_to(ARCHIVE_ROOT) or not cand.is_dir():
+            print(f"Warning: refusing folder '{name}' (not an allowed platform dir)")
+            continue
+        folders.append(cand)
     
     if not folders:
         print("No valid folders found")


### PR DESCRIPTION
This PR enhances the build_archives script to restrict out of tree usage and only allow listed folders when creating archives.
This vulnerability was identified by mythos and requested through the ticket : 
https://amd.atlassian.net/browse/SWSPLAT-30783