### PR TITLE
harden validation scripts against env-controlled execution paths and MMIO targets

### DIFF
--- a/archive/ve2/t50/platform_validation.sh
+++ b/archive/ve2/t50/platform_validation.sh
@@ -2,14 +2,15 @@
 
 set -euo pipefail
 
-# This recipe installs under .../amdxdna/bins/t50/; other packages use the parent tree.
-AMDXDNA_BINS="${AMDXDNA_BINS:-/usr/share/amdxdna/bins/t50}"
-AMDXDNA_BINS_TOP="${AMDXDNA_BINS_TOP:-/usr/share/amdxdna/bins}"
-DEVICE="${DEVICE:-0}"
+# Helper paths are derived from this script's install location — never from the
+# environment. Do not add this launcher to sudoers without env_reset.
+readonly SELF_DIR="$(cd -- "$(dirname -- "$(readlink -f -- "$0")")" && pwd)"
+readonly AMDXDNA_BINS="$SELF_DIR"
+readonly AMDXDNA_BINS_TOP="$(cd -- "${SELF_DIR}/.." && pwd)"
+readonly PS_AIE_CONNECTIONS_SH="${AMDXDNA_BINS}/ps_aie_connections/ps_aie_connections.sh"
+readonly PS_AIE_CERT_WAKEUP_SH="${AMDXDNA_BINS}/ps_aie_cert_wakeup/ps_aie_cert_wakeup.sh"
 
-# This launcher lives in AMDXDNA_BINS; helper scripts each have a subdirectory there.
-PS_AIE_CONNECTIONS_SH="${PS_AIE_CONNECTIONS_SH:-${AMDXDNA_BINS}/ps_aie_connections/ps_aie_connections.sh}"
-PS_AIE_CERT_WAKEUP_SH="${PS_AIE_CERT_WAKEUP_SH:-${AMDXDNA_BINS}/ps_aie_cert_wakeup/ps_aie_cert_wakeup.sh}"
+DEVICE="${DEVICE:-0}"
 
 usage() {
 	cat <<EOF
@@ -26,12 +27,12 @@ Usage: ${0##*/} [all | N [N ...]]
   8                 ps_aie_cert_wakeup/ps_aie_cert_wakeup.sh (uC wakeup + handshake 0x0FFE per column)
   9                 xrt-runner shim_dma_bandwidth test (shim DMA BW)
 
+Paths (fixed relative to this script):
+  AMDXDNA_BINS=$AMDXDNA_BINS
+  AMDXDNA_BINS_TOP=$AMDXDNA_BINS_TOP
+
 Environment:
   DEVICE=$DEVICE (default 0)
-  AMDXDNA_BINS=$AMDXDNA_BINS (this recipe; default .../bins/t50)
-  AMDXDNA_BINS_TOP=$AMDXDNA_BINS_TOP (sibling packages e.g. aie_ddr_connections; default .../bins)
-  PS_AIE_CONNECTIONS_SH=$PS_AIE_CONNECTIONS_SH
-  PS_AIE_CERT_WAKEUP_SH=$PS_AIE_CERT_WAKEUP_SH
 EOF
 }
 

--- a/archive/ve2/t50/ps_aie_cert_wakeup/ps_aie_cert_wakeup.sh
+++ b/archive/ve2/t50/ps_aie_cert_wakeup/ps_aie_cert_wakeup.sh
@@ -3,32 +3,45 @@
 set -euo pipefail
 
 # Per-column uC wakeup + firmware handshake (cert) state via devmem2.
-# Defaults match VE2 column stride; override with env if your map differs.
+# VE2 register map is fixed; MMIO targets are clamped to the AIE aperture.
 
-DEVMEM2=${DEVMEM2:-devmem2}
-STATE_REG=${STATE_REG:-0x200000880A0}
-WAKE_REG=${WAKE_REG:-0x200000C0004}
+readonly DEVMEM2=devmem2
+readonly VE2_AIE_BASE=0x20000000000
+readonly VE2_AIE_SIZE=0x00080000000
+readonly STATE_REG=0x200000880A0
+readonly WAKE_REG=0x200000C0004
+readonly COL_SHIFT=25
+readonly COL_LAST=35
+
 WAKE_VAL=${WAKE_VAL:-1}
 EXPECT_STATE=${EXPECT_STATE:-0x0FFE}
 STATE_MASK=${STATE_MASK:-0xFFFF}
-COL_LAST=${COL_LAST:-35}
-COL_SHIFT=${COL_SHIFT:-25}
 POST_WAKE_SLEEP=${POST_WAKE_SLEEP:-0.05}
 
 strip() { local z=${1#0x}; echo "${z#0X}"; }
 
-state_base=$((16#$(strip "$STATE_REG")))
-wake_base=$((16#$(strip "$WAKE_REG")))
+in_aie_window() {
+	local a=$1
+	((a >= VE2_AIE_BASE && a < VE2_AIE_BASE + VE2_AIE_SIZE))
+}
+
+assert_aie_window() {
+	local addr=$1 label=$2
+	in_aie_window "$addr" || {
+		printf 'error: refusing OOB MMIO %s @0x%X (outside VE2 AIE window [0x%X, 0x%X))\n' \
+			"$label" "$addr" "$VE2_AIE_BASE" $((VE2_AIE_BASE + VE2_AIE_SIZE)) >&2
+		exit 1
+	}
+}
+
+state_base=$STATE_REG
+wake_base=$WAKE_REG
 mask=$((16#$(strip "$STATE_MASK")))
 want=$((16#$(strip "$EXPECT_STATE")))
 want=$((want & mask))
 
 command -v "$DEVMEM2" >/dev/null 2>&1 || {
 	echo "error: $DEVMEM2 not found" >&2
-	exit 1
-}
-((COL_LAST <= 36)) || {
-	echo "error: COL_LAST must be 0..36" >&2
 	exit 1
 }
 
@@ -47,6 +60,9 @@ for col in $(seq 0 "$COL_LAST"); do
 	wake_addr=$((wake_base + off))
 	rh=$(printf '0x%X' "$read_addr")
 	wh=$(printf '0x%X' "$wake_addr")
+
+	assert_aie_window "$wake_addr" "wake_addr col=$col"
+	assert_aie_window "$read_addr" "read_addr col=$col"
 
 	set +e
 	wo=$("$DEVMEM2" "$wh" w "$WAKE_VAL" 2>&1)

--- a/archive/ve2/t50/ps_aie_connections/ps_aie_connections.sh
+++ b/archive/ve2/t50/ps_aie_connections/ps_aie_connections.sh
@@ -2,21 +2,39 @@
 
 set -euo pipefail
 
-DEVMEM2=${DEVMEM2:-devmem2}
-EXPECT=${EXPECT:-0xDEADBEEF}
-ADDR_BASE=${ADDR_BASE:-0}
-COL_LAST=${COL_LAST:-36}
+# PS↔AIE column read/write check via devmem2.
+# VE2 column-memory base is fixed; MMIO targets are clamped to the AIE aperture.
+
+readonly DEVMEM2=devmem2
+readonly VE2_AIE_BASE=0x20000000000
+readonly VE2_AIE_SIZE=0x00080000000
+readonly ADDR_BASE=0x20000000000
+readonly EXPECT=0xDEADBEEF
+readonly COL_SHIFT=25
+readonly COL_OFFSET=$((1 << 20))
+readonly COL_LAST=36
 
 strip() { local z=${1#0x}; echo "${z#0X}"; }
+
+in_aie_window() {
+	local a=$1
+	((a >= VE2_AIE_BASE && a < VE2_AIE_BASE + VE2_AIE_SIZE))
+}
+
+assert_aie_window() {
+	local addr=$1 label=$2
+	in_aie_window "$addr" || {
+		printf 'error: refusing OOB MMIO %s @0x%X (outside VE2 AIE window [0x%X, 0x%X))\n' \
+			"$label" "$addr" "$VE2_AIE_BASE" $((VE2_AIE_BASE + VE2_AIE_SIZE)) >&2
+		exit 1
+	}
+}
+
 want=$(printf %08X $((16#$(strip "$EXPECT"))))
-base=$((16#$(strip "$ADDR_BASE")))
+base=$ADDR_BASE
 
 command -v "$DEVMEM2" >/dev/null 2>&1 || {
 	echo "error: $DEVMEM2 not found" >&2
-	exit 1
-}
-((COL_LAST <= 36)) || {
-	echo "error: COL_LAST must be 0..36" >&2
 	exit 1
 }
 
@@ -30,8 +48,10 @@ read_hex() {
 }
 
 for col in $(seq 0 "$COL_LAST"); do
-	a=$((base + (col << 25) + (1 << 20)))
+	a=$((base + (col << COL_SHIFT) + COL_OFFSET))
 	h=$(printf '0x%08X' "$a")
+
+	assert_aie_window "$a" "col=$col"
 
 	set +e
 	wo=$("$DEVMEM2" "$h" w "$EXPECT" 2>&1)


### PR DESCRIPTION
https://amd.atlassian.net/browse/SWSPLAT-30785
https://amd.atlassian.net/browse/SWSPLAT-30779
https://amd.atlassian.net/browse/SWSPLAT-30777

Replace environment-driven helper paths and devmem2 physical addresses with readonly constants derived from the VE2 register map and script install location. Add AIE aperture checks before each devmem2 access to block out-of-bounds MMIO writes.

- platform_validation.sh: resolve PS_AIE_* paths from $0 instead of env
- ps_aie_cert_wakeup.sh: pin STATE_REG/WAKE_REG and validate MMIO window
- ps_aie_connections.sh: set ADDR_BASE to 0x20000000000 and validate MMIO window