### PR TITLE
Add vadd ifm ofm wts binaries

### DIFF
--- a/archive/ve2/vadd/ifm.bin
+++ b/archive/ve2/vadd/ifm.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8808405eec6fbe306fe3369f88daed79dd5613ddbb5e801f632b01d6218c5f08
+size 1024

--- a/archive/ve2/vadd/ofm.bin
+++ b/archive/ve2/vadd/ofm.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3f9b10bbddc4300f2368969ae20de05e7b4583553168e44e357f1e4f9ddc306b
+size 1024

--- a/archive/ve2/vadd/wts.bin
+++ b/archive/ve2/vadd/wts.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:847472bf949792a07f57684044606ece9e22ae5af5215cf732f84a9cfe9dbf16
+size 64


### PR DESCRIPTION
This PR has included ifm ofm wts binaries to support additional shim test for ve2