### PR TITLE
AIESW-42184: df-bw validate output data correctness

### DIFF
--- a/archive/npu3/df_bandwidth/profile_df_bandwidth.json
+++ b/archive/npu3/df_bandwidth/profile_df_bandwidth.json
@@ -3,7 +3,7 @@
   "bindings" : [
     {
       "name" : "ifm",
-      "size" : 1073741824,
+      "size" : 1073479680,
       "init" : {
         "stride": 4,
         "value": 3735928559
@@ -11,15 +11,19 @@
     },
     {
       "name" : "ofm",
-      "size" : 1073741824,
+      "size" : 1073479680,
       "init" : {
         "stride": 4,
         "value": 0
+      },
+      "validate" : {
+        "name" : "ifm"
       }
     }
   ],
   "execution" : {
     "iterations": 100,
+    "validate": true,
     "iteration" : {
       "init" : false
     },

--- a/archive/npu3/df_bandwidth/recipe_df_bandwidth.json
+++ b/archive/npu3/df_bandwidth/recipe_df_bandwidth.json
@@ -5,8 +5,8 @@
   },
   "resources": {
     "buffers": [
-      { "name": "ifm", "type": "input", "size": 1073741824 },
-      { "name": "ofm", "type": "input", "size": 1073741824 }
+      { "name": "ifm", "type": "input", "size": 1073479680 },
+      { "name": "ofm", "type": "input", "size": 1073479680 }
     ],
     "kernels": [
       { "name": "k1", "instance": "DPU"}


### PR DESCRIPTION
AIESW-42184: Add output buffer validation to the npu3 df-bw test. The test now
compares ofm against ifm after all iterations complete to confirm
the DMA transfer was successful before reporting bandwidth.

Also correct buffer sizes from 1073741824 to 1073479680 to match
the actual transfer size of the df_bw ELF (1GB - 256KB).

Validation runs once after all iterations and outside the timer,
so reported bandwidth is unaffected.

Changes:
- profile_df_bandwidth.json: corrected buffer sizes, added validate
  node on ofm, enabled validate: true in execution
- recipe_df_bandwidth.json: corrected buffer sizes
- xrt_smi_npu3.a: rebuilt archive

Archive build output:
  Updating xrt_smi_npu3.a (npu3) from 40 files...
  Files updated (2):
    ~ profile_df_bandwidth.json
    ~ recipe_df_bandwidth.json

```
Test result on NPU Medusa B0:
  xrt-smi validate --advanced -r df-bw
  Test 1 [0083:00:01.1] : df-bw
      Details            : Average bandwidth per shim DMA: 106.6 GB/s
      Test Status        : [PASSED]
```

Fixes: https://jira.xilinx.com/browse/AIESW-42184
